### PR TITLE
fix(api.d.ts): updated typescript definitions for getBaseCstVisitorCo…

### DIFF
--- a/packages/types/api.d.ts
+++ b/packages/types/api.d.ts
@@ -45,12 +45,12 @@ declare abstract class BaseParser {
    */
   reset(): void
 
-  getBaseCstVisitorConstructor(): {
-    new (...args: any[]): ICstVisitor<any, any>
+  getBaseCstVisitorConstructor<IN = any, OUT = any>(): {
+    new (...args: any[]): ICstVisitor<IN, OUT>
   }
 
-  getBaseCstVisitorConstructorWithDefaults(): {
-    new (...args: any[]): ICstVisitor<any, any>
+  getBaseCstVisitorConstructorWithDefaults<IN = any, OUT = any>(): {
+    new (...args: any[]): ICstVisitor<IN, OUT>
   }
 
   getGAstProductions(): Record<string, Rule>


### PR DESCRIPTION
…nstructor functions

Generics were added to getBaseCstVisitorConstructor() and getBaseCstVisitorConstructorWithDefaults()
in PR #1303. However, the typescript definitions were not updated.